### PR TITLE
build: fix built-in build task script

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,7 @@
 		{
 			"label": "Copy to Custom Connectors folder",
 			"type": "shell",
-			"command": "cp .\\bin\\AnyCPU\\Debug\\Odoo.mez $(Join-Path $([environment]::getfolderpath('mydocuments')) 'Power BI Desktop' 'Custom Connectors')",
+			"command": "cp .\\bin\\AnyCPU\\Debug\\Odoo.mez $(Join-Path $([environment]::getfolderpath('mydocuments')) $(Join-Path 'Power BI Desktop' 'Custom Connectors'))",
 			"problemMatcher": []
 		},
 		{


### PR DESCRIPTION
When building, I was getting a failure due to `Join-Path` only accepting 2 arguments.

I added a sub-call to it, so it builds properly now.

@moduon MT-7033